### PR TITLE
MUS-17: update dto

### DIFF
--- a/lib/mus-internal/mus-dto/include/mus-dto/playlist_response_dto.h
+++ b/lib/mus-internal/mus-dto/include/mus-dto/playlist_response_dto.h
@@ -6,15 +6,14 @@
 
 struct PlaylistResponseDTO {
     PlaylistResponseDTO(uint32_t id_, uint32_t author_id_, uint32_t songs_count_,
-                        uint32_t likes_count_, std::string title_)
+                        std::string title_)
                         : id(id_), author_id(author_id_),
-                        songs_count(songs_count_), likes_count(likes_count_),
+                        songs_count(songs_count_),
                         title(title_) {}
 
     uint32_t id;
     uint32_t author_id;
     uint32_t songs_count;
-    uint32_t likes_count;
     std::string title;
 };
 

--- a/lib/mus-internal/mus-dto/include/mus-dto/user_request_dto.h
+++ b/lib/mus-internal/mus-dto/include/mus-dto/user_request_dto.h
@@ -5,13 +5,11 @@
 #include <string>
 
 struct UserRequestDTO {
-    UserRequestDTO(uint32_t id_, std::string username_,
-                   std::string password_, std::string nickname_,
-                   std::string email_)
+    UserRequestDTO(std::string username_, std::string password_,
+                   std::string nickname_, std::string email_)
                     : username(username_), password(password_),
                     nickname(nickname_), id(id_), email(email_) {}
 
-    uint32_t id;
     std::string username;
     std::string password;
     std::string nickname;


### PR DESCRIPTION
Исправила UserRequestDTO, в котором убрала поле id, и PlaylistResponseDTO, в котором убрала поле likes_count.