### PR TITLE
Mus 33/usecase refactor

### DIFF
--- a/lib/mus-internal/mus-dto/include/mus-dto/message_request_dto.h
+++ b/lib/mus-internal/mus-dto/include/mus-dto/message_request_dto.h
@@ -7,13 +7,17 @@
 #include <string>
 
 struct MessageRequestDTO {
-    MessageRequestDTO(const std::string& content_)
-                    : content(content_) {}
+    MessageRequestDTO(const std::string& content_,
+                      std::optional<uint32_t> playlist_id_ = {})
+                    : content(content_),
+                      playlist_id(playlist_id_) {}
 
     std::string content;
+    std::optional<uint32_t> playlist_id;
 
     constexpr static auto properties = std::tuple(
-        music_share::reflectable::Property(&MessageRequestDTO::content, "content")
+        music_share::reflectable::Property(&MessageRequestDTO::content, "content"),
+        music_share::reflectable::Property(&MessageRequestDTO::playlist_id, "playlistId")
     );
 };
 

--- a/lib/mus-internal/mus-dto/include/mus-dto/message_response_dto.h
+++ b/lib/mus-internal/mus-dto/include/mus-dto/message_response_dto.h
@@ -12,9 +12,12 @@ struct MessageResponseDTO {
     MessageResponseDTO(uint32_t id_, uint32_t chat_id_,
                        uint32_t sender_id_,
                        const std::string& content_,
-                       const std::string& datetime_)
+                       const std::string& datetime_,
+                       std::optional<uint32_t> playlist_id_ = {})
                        : id(id_), chat_id(chat_id_), sender_id(sender_id_),
-                       content(content_), datetime(datetime_) {}
+                       content(content_), datetime(datetime_),
+                       playlist_id(playlist_id_)
+                       {}
 
     uint32_t id;
     uint32_t chat_id;

--- a/lib/mus-internal/mus-dto/include/mus-dto/message_response_dto.h
+++ b/lib/mus-internal/mus-dto/include/mus-dto/message_response_dto.h
@@ -5,6 +5,7 @@
 
 #include <tuple>
 #include <cstdint>
+#include <optional>
 #include <string>
 
 struct MessageResponseDTO {
@@ -20,13 +21,15 @@ struct MessageResponseDTO {
     uint32_t sender_id;
     std::string content;
     std::string datetime;
+    std::optional<uint32_t> playlist_id;
 
     constexpr static auto properties = std::tuple(
         music_share::reflectable::Property(&MessageResponseDTO::id, "id"),
         music_share::reflectable::Property(&MessageResponseDTO::chat_id, "chatId"),
         music_share::reflectable::Property(&MessageResponseDTO::sender_id, "senderId"),
         music_share::reflectable::Property(&MessageResponseDTO::content, "content"),
-        music_share::reflectable::Property(&MessageResponseDTO::datetime, "datetime")
+        music_share::reflectable::Property(&MessageResponseDTO::datetime, "datetime"),
+        music_share::reflectable::Property(&MessageResponseDTO::playlist_id, "playlistId")
     );
 };
 

--- a/lib/mus-internal/mus-iusecase/include/mus-iusecase/ichat_message_use_case.h
+++ b/lib/mus-internal/mus-iusecase/include/mus-iusecase/ichat_message_use_case.h
@@ -19,10 +19,10 @@ namespace music_share {
 
         virtual uint32_t SendMessage(const MessageRequestDTO& message_dto,
                                      uint32_t chat_id, uint32_t user_id,
-                                     std::optional<std::string> datetime = std::nullopt) = 0;
+                                     std::optional<std::string> datetime) = 0;
 
         virtual std::vector<MessageResponseDTO> GetUserMessages(uint32_t user_id,
-                                                                uint32_t chat_id) = 0;
+                                                                uint32_t chat_id) const = 0;
 
         virtual ~IChatMessageUseCase() = default;
     };

--- a/lib/mus-internal/mus-iusecase/include/mus-iusecase/ichat_message_use_case.h
+++ b/lib/mus-internal/mus-iusecase/include/mus-iusecase/ichat_message_use_case.h
@@ -24,6 +24,9 @@ namespace music_share {
         virtual std::vector<MessageResponseDTO> GetUserMessages(uint32_t user_id,
                                                                 uint32_t chat_id) const = 0;
 
+        virtual std::vector<MessageResponseDTO> GetByUserId(uint32_t user_id,
+                                                            std::optional<std::string> since_datetime) const = 0;
+
         virtual ~IChatMessageUseCase() = default;
     };
 

--- a/lib/mus-internal/mus-iusecase/include/mus-iusecase/ichat_message_use_case.h
+++ b/lib/mus-internal/mus-iusecase/include/mus-iusecase/ichat_message_use_case.h
@@ -19,7 +19,7 @@ namespace music_share {
 
         virtual uint32_t SendMessage(const MessageRequestDTO& message_dto,
                                      uint32_t chat_id, uint32_t user_id,
-                                     std::optional<std::string> datetime) = 0;
+                                     std::optional<std::string> datetime = std::nullopt) = 0;
 
         virtual std::vector<MessageResponseDTO> GetUserMessages(uint32_t user_id,
                                                                 uint32_t chat_id) const = 0;

--- a/lib/mus-internal/mus-iusecase/include/mus-iusecase/ichat_use_case.h
+++ b/lib/mus-internal/mus-iusecase/include/mus-iusecase/ichat_use_case.h
@@ -20,10 +20,10 @@ public:
     virtual uint32_t Create(uint32_t user_id,
                             const ChatRequestDTO& chat) = 0;
 
-    virtual std::vector<ChatResponseDTO> GetByIdOfOneUser(uint32_t id) = 0;
+    virtual std::vector<ChatResponseDTO> GetByIdOfOneUser(uint32_t id) const = 0;
 
     virtual ChatResponseDTO GetByIdOfTwoUser(uint32_t first_id,
-                                             uint32_t second_id) = 0;
+                                             uint32_t second_id) const = 0;
 
     virtual ~IChatUseCase() = default;
 };

--- a/lib/mus-internal/mus-iusecase/include/mus-iusecase/iplaylist_use_case.h
+++ b/lib/mus-internal/mus-iusecase/include/mus-iusecase/iplaylist_use_case.h
@@ -31,11 +31,11 @@ public:
     virtual void DeleteSongById(uint32_t song_id, uint32_t playlist_id,
                                 uint32_t user_id) = 0;
 
-    virtual std::vector<PlaylistResponseDTO> GetByUserId(uint32_t user_id) = 0;
+    virtual std::vector<PlaylistResponseDTO> GetByUserId(uint32_t user_id) const = 0;
 
-    virtual PlaylistResponseDTO GetById(uint32_t id) = 0;
+    virtual PlaylistResponseDTO GetById(uint32_t id) const = 0;
 
-    virtual std::vector<uint32_t> GetSongs(uint32_t playlist_id) = 0;
+    virtual std::vector<uint32_t> GetSongs(uint32_t playlist_id) const = 0;
 
     virtual ~IPlaylistUseCase() = default;
 };

--- a/lib/mus-internal/mus-iusecase/include/mus-iusecase/isong_use_case.h
+++ b/lib/mus-internal/mus-iusecase/include/mus-iusecase/isong_use_case.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <string>
 #include <vector>
+#include <optional>
 
 #include "mus-dto/song_response_dto.h"
 
@@ -19,9 +20,8 @@ public:
 
     virtual SongResponseDTO GetById(uint32_t id) const = 0;
 
-    virtual std::vector<SongResponseDTO> GetByTitle(const std::string& title) const = 0;
-
-    virtual std::vector<SongResponseDTO> GetByArtist(const std::string& artist) const = 0;
+    virtual std::vector<SongResponseDTO> GetByArtistAndTitle(const std::optional<std::string>& artist,
+                                                             const std::optional<std::string>& title) const = 0;
 
     virtual ~ISongUseCase() = default;
 };

--- a/lib/mus-internal/mus-iusecase/include/mus-iusecase/isong_use_case.h
+++ b/lib/mus-internal/mus-iusecase/include/mus-iusecase/isong_use_case.h
@@ -20,8 +20,8 @@ public:
 
     virtual SongResponseDTO GetById(uint32_t id) const = 0;
 
-    virtual std::vector<SongResponseDTO> GetByArtistAndTitle(const std::optional<std::string> artist,
-                                                             const std::optional<std::string> title) const = 0;
+    virtual std::vector<SongResponseDTO> GetByArtistAndTitle(const std::optional<std::string> artist = {},
+                                                             const std::optional<std::string> title = {}) const = 0;
 
     virtual ~ISongUseCase() = default;
 };

--- a/lib/mus-internal/mus-iusecase/include/mus-iusecase/isong_use_case.h
+++ b/lib/mus-internal/mus-iusecase/include/mus-iusecase/isong_use_case.h
@@ -17,11 +17,11 @@ public:
 
     ISongUseCase& operator=(const ISongUseCase& song_use_case) = default;
 
-    virtual SongResponseDTO GetById(uint32_t id) = 0;
+    virtual SongResponseDTO GetById(uint32_t id) const = 0;
 
-    virtual std::vector<SongResponseDTO> GetByTitle(const std::string& title) = 0;
+    virtual std::vector<SongResponseDTO> GetByTitle(const std::string& title) const = 0;
 
-    virtual std::vector<SongResponseDTO> GetByArtist(const std::string& artist) = 0;
+    virtual std::vector<SongResponseDTO> GetByArtist(const std::string& artist) const = 0;
 
     virtual ~ISongUseCase() = default;
 };

--- a/lib/mus-internal/mus-iusecase/include/mus-iusecase/isong_use_case.h
+++ b/lib/mus-internal/mus-iusecase/include/mus-iusecase/isong_use_case.h
@@ -20,8 +20,8 @@ public:
 
     virtual SongResponseDTO GetById(uint32_t id) const = 0;
 
-    virtual std::vector<SongResponseDTO> GetByArtistAndTitle(const std::optional<std::string>& artist,
-                                                             const std::optional<std::string>& title) const = 0;
+    virtual std::vector<SongResponseDTO> GetByArtistAndTitle(const std::optional<std::string> artist,
+                                                             const std::optional<std::string> title) const = 0;
 
     virtual ~ISongUseCase() = default;
 };

--- a/lib/mus-internal/mus-iusecase/include/mus-iusecase/iuser_use_case.h
+++ b/lib/mus-internal/mus-iusecase/include/mus-iusecase/iuser_use_case.h
@@ -22,11 +22,11 @@ public:
     virtual UserResponseDTO Update(uint32_t user_id,
                                    const UserRequestDTO& user_dto) = 0;
 
-    virtual UserResponseDTO GetByUsername(const std::string& username) = 0;
+    virtual UserResponseDTO GetByUsername(const std::string& username) const = 0;
 
-    virtual std::vector<UserResponseDTO> GetByNicknames(const std::vector<std::string>& nicknames) = 0;
+    virtual std::vector<UserResponseDTO> GetByNicknames(const std::vector<std::string>& nicknames) const = 0;
 
-    virtual UserResponseDTO GetById(uint32_t id) = 0;
+    virtual UserResponseDTO GetById(uint32_t id) const = 0;
 
     virtual ~IUserUseCase() = default;
 };

--- a/lib/mus-internal/mus-iusecase/include/mus-iusecase/iuser_use_case.h
+++ b/lib/mus-internal/mus-iusecase/include/mus-iusecase/iuser_use_case.h
@@ -24,7 +24,7 @@ public:
 
     virtual UserResponseDTO GetByUsername(const std::string& username) const = 0;
 
-    virtual std::vector<UserResponseDTO> GetByNicknames(const std::vector<std::string>& nicknames) const = 0;
+    virtual std::vector<UserResponseDTO> GetByNicknames(const std::vector<std::string> nicknames) const = 0;
 
     virtual UserResponseDTO GetById(uint32_t id) const = 0;
 

--- a/lib/mus-internal/mus-usecase/include/mus-usecase/chat_message_use_case.h
+++ b/lib/mus-internal/mus-usecase/include/mus-usecase/chat_message_use_case.h
@@ -25,7 +25,7 @@ namespace music_share {
                              std::optional<std::string> datetime = std::nullopt) override;
 
         std::vector<MessageResponseDTO> GetUserMessages(uint32_t user_id,
-                                                        uint32_t chat_id) override;
+                                                        uint32_t chat_id) const override;
 
         ~ChatMessageUseCase() = default;
 

--- a/lib/mus-internal/mus-usecase/include/mus-usecase/chat_message_use_case.h
+++ b/lib/mus-internal/mus-usecase/include/mus-usecase/chat_message_use_case.h
@@ -22,7 +22,7 @@ namespace music_share {
 
         uint32_t SendMessage(const MessageRequestDTO& message_dto, uint32_t chat_id,
                              uint32_t user_id,
-                             std::optional<std::string> datetime = std::nullopt) override;
+                             std::optional<std::string> datetime) override;
 
         std::vector<MessageResponseDTO> GetUserMessages(uint32_t user_id,
                                                         uint32_t chat_id) const override;

--- a/lib/mus-internal/mus-usecase/include/mus-usecase/chat_message_use_case.h
+++ b/lib/mus-internal/mus-usecase/include/mus-usecase/chat_message_use_case.h
@@ -27,6 +27,9 @@ namespace music_share {
         std::vector<MessageResponseDTO> GetUserMessages(uint32_t user_id,
                                                         uint32_t chat_id) const override;
 
+        std::vector<MessageResponseDTO> GetByUserId(uint32_t user_id,
+                                                    std::optional<std::string> since_datetime) const override;
+
         ~ChatMessageUseCase() = default;
 
     private:

--- a/lib/mus-internal/mus-usecase/include/mus-usecase/chat_use_case.h
+++ b/lib/mus-internal/mus-usecase/include/mus-usecase/chat_use_case.h
@@ -21,10 +21,10 @@ namespace music_share {
         uint32_t Create(uint32_t user_id,
                         const ChatRequestDTO& chat) override;
 
-        std::vector<ChatResponseDTO> GetByIdOfOneUser(uint32_t id) override;
+        std::vector<ChatResponseDTO> GetByIdOfOneUser(uint32_t id) const override;
 
         ChatResponseDTO GetByIdOfTwoUser(uint32_t first_id,
-                                         uint32_t second_id) override;
+                                         uint32_t second_id) const override;
 
         ~ChatUseCase() = default;
 

--- a/lib/mus-internal/mus-usecase/include/mus-usecase/playlist_use_case.h
+++ b/lib/mus-internal/mus-usecase/include/mus-usecase/playlist_use_case.h
@@ -33,11 +33,11 @@ namespace music_share {
         void DeleteSongById(uint32_t song_id, uint32_t playlist_id,
                             uint32_t user_id) override;
 
-        std::vector<PlaylistResponseDTO> GetByUserId(uint32_t user_id) override;
+        std::vector<PlaylistResponseDTO> GetByUserId(uint32_t user_id) const override;
 
-        PlaylistResponseDTO GetById(uint32_t id) override;
+        PlaylistResponseDTO GetById(uint32_t id) const override;
 
-        std::vector<uint32_t> GetSongs(uint32_t playlist_id) override;
+        std::vector<uint32_t> GetSongs(uint32_t playlist_id) const override;
 
         ~PlaylistUseCase() = default;
 

--- a/lib/mus-internal/mus-usecase/include/mus-usecase/song_use_case.h
+++ b/lib/mus-internal/mus-usecase/include/mus-usecase/song_use_case.h
@@ -18,11 +18,11 @@ namespace music_share {
 
         SongUseCase &operator=(const SongUseCase& song_use_case);
 
-        SongResponseDTO GetById(uint32_t id) override;
+        SongResponseDTO GetById(uint32_t id) const override;
 
-        std::vector<SongResponseDTO> GetByTitle(const std::string& title) override;
+        std::vector<SongResponseDTO> GetByTitle(const std::string& title) const override;
 
-        std::vector<SongResponseDTO> GetByArtist(const std::string& artist) override;
+        std::vector<SongResponseDTO> GetByArtist(const std::string& artist) const override;
 
         ~SongUseCase() = default;
 

--- a/lib/mus-internal/mus-usecase/include/mus-usecase/song_use_case.h
+++ b/lib/mus-internal/mus-usecase/include/mus-usecase/song_use_case.h
@@ -20,8 +20,8 @@ namespace music_share {
 
         SongResponseDTO GetById(uint32_t id) const override;
 
-        std::vector<SongResponseDTO> GetByArtistAndTitle(const std::optional<std::string> artist = {},
-                                                         const std::optional<std::string> title = {}) const override;
+        std::vector<SongResponseDTO> GetByArtistAndTitle(const std::optional<std::string> artist,
+                                                         const std::optional<std::string> title) const override;
 
         ~SongUseCase() = default;
 

--- a/lib/mus-internal/mus-usecase/include/mus-usecase/song_use_case.h
+++ b/lib/mus-internal/mus-usecase/include/mus-usecase/song_use_case.h
@@ -20,9 +20,8 @@ namespace music_share {
 
         SongResponseDTO GetById(uint32_t id) const override;
 
-        std::vector<SongResponseDTO> GetByTitle(const std::string& title) const override;
-
-        std::vector<SongResponseDTO> GetByArtist(const std::string& artist) const override;
+        std::vector<SongResponseDTO> GetByArtistAndTitle(const std::optional<std::string>& artist = {},
+                                                         const std::optional<std::string>& title = {}) const override;
 
         ~SongUseCase() = default;
 

--- a/lib/mus-internal/mus-usecase/include/mus-usecase/song_use_case.h
+++ b/lib/mus-internal/mus-usecase/include/mus-usecase/song_use_case.h
@@ -20,8 +20,8 @@ namespace music_share {
 
         SongResponseDTO GetById(uint32_t id) const override;
 
-        std::vector<SongResponseDTO> GetByArtistAndTitle(const std::optional<std::string>& artist = {},
-                                                         const std::optional<std::string>& title = {}) const override;
+        std::vector<SongResponseDTO> GetByArtistAndTitle(const std::optional<std::string> artist = {},
+                                                         const std::optional<std::string> title = {}) const override;
 
         ~SongUseCase() = default;
 

--- a/lib/mus-internal/mus-usecase/include/mus-usecase/user_use_case.h
+++ b/lib/mus-internal/mus-usecase/include/mus-usecase/user_use_case.h
@@ -26,7 +26,7 @@ namespace music_share {
 
         UserResponseDTO GetByUsername(const std::string& username) const override;
 
-        std::vector<UserResponseDTO> GetByNicknames(const std::vector<std::string>& nicknames) const override;
+        std::vector<UserResponseDTO> GetByNicknames(const std::vector<std::string> nicknames) const override;
 
         UserResponseDTO GetById(uint32_t id) const override;
 

--- a/lib/mus-internal/mus-usecase/include/mus-usecase/user_use_case.h
+++ b/lib/mus-internal/mus-usecase/include/mus-usecase/user_use_case.h
@@ -24,11 +24,11 @@ namespace music_share {
         UserResponseDTO Update(uint32_t user_id,
                                const UserRequestDTO& user_dto) override;
 
-        UserResponseDTO GetByUsername(const std::string& username) override;
+        UserResponseDTO GetByUsername(const std::string& username) const override;
 
-        std::vector<UserResponseDTO> GetByNicknames(const std::vector<std::string>& nicknames) override;
+        std::vector<UserResponseDTO> GetByNicknames(const std::vector<std::string>& nicknames) const override;
 
-        UserResponseDTO GetById(uint32_t id) override;
+        UserResponseDTO GetById(uint32_t id) const override;
 
         ~UserUseCase() = default;
 

--- a/lib/mus-internal/mus-usecase/src/chat_message_use_case.cc
+++ b/lib/mus-internal/mus-usecase/src/chat_message_use_case.cc
@@ -103,7 +103,8 @@ namespace music_share {
                                       message.GetChatId(),
                                       message.GetSenderId(),
                                       message.GetContent(),
-                                      message.GetDatetime());
+                                      message.GetDatetime(),
+                                      message.GetPlaylistId());
         }
 
         return messages_dto;

--- a/lib/mus-internal/mus-usecase/src/chat_message_use_case.cc
+++ b/lib/mus-internal/mus-usecase/src/chat_message_use_case.cc
@@ -51,6 +51,32 @@ namespace music_share {
         return *message.GetId();
     }
 
+    vector<MessageResponseDTO> ChatMessageUseCase::GetByUserId(uint32_t user_id,
+                                                                optional<string> since_datetime) const {
+        vector<ChatMessage> messages = m_chat_message_rep.FindByUserId(user_id,
+                                                                       since_datetime);
+
+        if (messages.empty()) {
+            return {};
+        }
+
+        vector<MessageResponseDTO> messages_dto;
+        messages_dto.reserve(messages.size());
+
+        for (const ChatMessage& message : messages) {
+            if (!message.GetId()) {
+                throw NullPointerException();
+            }
+            messages_dto.emplace_back(*message.GetId(),
+                                      message.GetChatId(),
+                                      message.GetSenderId(),
+                                      message.GetContent(),
+                                      message.GetDatetime());
+        }
+
+        return messages_dto;
+    }
+
     vector<MessageResponseDTO> ChatMessageUseCase::GetUserMessages(uint32_t user_id,
                                                                    uint32_t chat_id) const {
         vector<ChatMessage> messages = m_chat_message_rep.FindByChatId(chat_id);

--- a/lib/mus-internal/mus-usecase/src/chat_message_use_case.cc
+++ b/lib/mus-internal/mus-usecase/src/chat_message_use_case.cc
@@ -12,6 +12,7 @@
 using std::ctime;
 using std::make_unique;
 using std::optional;
+using std::nullopt;
 using std::string;
 using std::vector;
 using std::time_t;
@@ -42,7 +43,9 @@ namespace music_share {
         ChatMessage message(user_id,
                             *datetime,
                             message_dto.content,
-                            chat_id);
+                            chat_id,
+                            nullopt,
+                            message_dto.playlist_id);
         m_chat_message_rep.Insert(message);
 
         if (!message.GetId()) {
@@ -71,7 +74,8 @@ namespace music_share {
                                       message.GetChatId(),
                                       message.GetSenderId(),
                                       message.GetContent(),
-                                      message.GetDatetime());
+                                      message.GetDatetime(),
+                                      message.GetPlaylistId());
         }
 
         return messages_dto;

--- a/lib/mus-internal/mus-usecase/src/chat_message_use_case.cc
+++ b/lib/mus-internal/mus-usecase/src/chat_message_use_case.cc
@@ -51,7 +51,7 @@ namespace music_share {
     }
 
     vector<MessageResponseDTO> ChatMessageUseCase::GetUserMessages(uint32_t user_id,
-                                                                   uint32_t chat_id) {
+                                                                   uint32_t chat_id) const {
         vector<ChatMessage> messages = m_chat_message_rep.FindByChatId(chat_id);
 
         if (messages.empty()) {

--- a/lib/mus-internal/mus-usecase/src/chat_message_use_case.cc
+++ b/lib/mus-internal/mus-usecase/src/chat_message_use_case.cc
@@ -39,16 +39,16 @@ namespace music_share {
             datetime = ctime(&end_time);
         }
 
-        auto message = make_unique<ChatMessage>(user_id,
-                                                *datetime,
-                                                message_dto.content,
-                                                chat_id);
-        m_chat_message_rep.Insert(*message);
+        ChatMessage message(user_id,
+                            *datetime,
+                            message_dto.content,
+                            chat_id);
+        m_chat_message_rep.Insert(message);
 
-        if (!message->GetId()) {
+        if (!message.GetId()) {
             throw CreateException();
         }
-        return *message->GetId();
+        return *message.GetId();
     }
 
     vector<MessageResponseDTO> ChatMessageUseCase::GetUserMessages(uint32_t user_id,
@@ -56,7 +56,7 @@ namespace music_share {
         vector<ChatMessage> messages = m_chat_message_rep.FindByChatId(chat_id);
 
         if (messages.empty()) {
-            throw InvalidDataException();
+            return {};
         }
 
         vector<MessageResponseDTO> messages_dto;

--- a/lib/mus-internal/mus-usecase/src/chat_message_use_case.cc
+++ b/lib/mus-internal/mus-usecase/src/chat_message_use_case.cc
@@ -29,7 +29,8 @@ namespace music_share {
         return *this;
     }
 
-    uint32_t ChatMessageUseCase::SendMessage(const MessageRequestDTO& message_dto, uint32_t chat_id,
+    uint32_t ChatMessageUseCase::SendMessage(const MessageRequestDTO& message_dto,
+                                             uint32_t chat_id,
                                              uint32_t user_id,
                                              optional<string> datetime) {
         if (!datetime) {

--- a/lib/mus-internal/mus-usecase/src/chat_use_case.cc
+++ b/lib/mus-internal/mus-usecase/src/chat_use_case.cc
@@ -47,7 +47,7 @@ namespace music_share {
         return *chat->GetId();
     }
 
-    vector<ChatResponseDTO> ChatUseCase::GetByIdOfOneUser(uint32_t id) {
+    vector<ChatResponseDTO> ChatUseCase::GetByIdOfOneUser(uint32_t id) const {
         vector<Chat> chats = m_chat_rep.FindByUserId(id);
 
         if (chats.empty()) {
@@ -69,7 +69,7 @@ namespace music_share {
     }
 
     ChatResponseDTO ChatUseCase::GetByIdOfTwoUser(uint32_t first_id,
-                                                  uint32_t second_id) {
+                                                  uint32_t second_id) const {
         optional<Chat> chat = m_chat_rep.FindByIdsOfUserPair(first_id, second_id);
 
         if (!chat) {

--- a/lib/mus-internal/mus-usecase/src/chat_use_case.cc
+++ b/lib/mus-internal/mus-usecase/src/chat_use_case.cc
@@ -30,9 +30,9 @@ namespace music_share {
 
     uint32_t ChatUseCase::Create(uint32_t user_id,
                                  const ChatRequestDTO& chat_request_dto) {
-        optional<Chat> chat_valid = m_chat_rep.FindByIdsOfUserPair(user_id,
+        optional<Chat> chat_exist = m_chat_rep.FindByIdsOfUserPair(user_id,
                                                          chat_request_dto.target_id);
-        if (chat_valid) {
+        if (chat_exist) {
             throw ExistException();
         }
 
@@ -70,7 +70,8 @@ namespace music_share {
 
     ChatResponseDTO ChatUseCase::GetByIdOfTwoUser(uint32_t first_id,
                                                   uint32_t second_id) const {
-        optional<Chat> chat = m_chat_rep.FindByIdsOfUserPair(first_id, second_id);
+        optional<Chat> chat = m_chat_rep.FindByIdsOfUserPair(first_id,
+                                                             second_id);
 
         if (!chat) {
             throw InvalidDataException();

--- a/lib/mus-internal/mus-usecase/src/chat_use_case.cc
+++ b/lib/mus-internal/mus-usecase/src/chat_use_case.cc
@@ -36,22 +36,22 @@ namespace music_share {
             throw ExistException();
         }
 
-        auto chat = make_unique<Chat>(user_id,
-                                                    chat_request_dto.target_id);
+        Chat chat(user_id,
+                chat_request_dto.target_id);
 
-        m_chat_rep.Insert(*chat);
+        m_chat_rep.Insert(chat);
 
-        if (!chat->GetId()) {
+        if (!chat.GetId()) {
             throw CreateException();
         }
-        return *chat->GetId();
+        return *chat.GetId();
     }
 
     vector<ChatResponseDTO> ChatUseCase::GetByIdOfOneUser(uint32_t id) const {
         vector<Chat> chats = m_chat_rep.FindByUserId(id);
 
         if (chats.empty()) {
-            throw InvalidDataException();
+            return {};
         }
 
         vector<ChatResponseDTO> chats_dto;

--- a/lib/mus-internal/mus-usecase/src/playlist_use_case.cc
+++ b/lib/mus-internal/mus-usecase/src/playlist_use_case.cc
@@ -30,16 +30,16 @@ namespace  music_share {
 
     uint32_t PlaylistUseCase::Create(uint32_t user_id,
                                      const PlaylistRequestDTO& playlist_dto) {
-        auto playlist = make_unique<Playlist>(playlist_dto.name,
-                                                                user_id,
-                                                                playlist_dto.song_ids);
+        Playlist playlist (playlist_dto.name,
+                           user_id,
+                           playlist_dto.song_ids);
 
-        m_playlist_rep.Insert(*playlist);
+        m_playlist_rep.Insert(playlist);
 
-        if (!playlist->GetId()) {
+        if (!playlist.GetId()) {
             throw CreateException();
         }
-        return *playlist->GetId();
+        return *playlist.GetId();
     }
 
     void PlaylistUseCase::DeleteById(uint32_t user_id,
@@ -94,7 +94,7 @@ namespace  music_share {
         vector<Playlist> playlists = m_playlist_rep.FindByUserId(user_id);
 
         if (playlists.empty()) {
-            throw InvalidDataException();
+            return {};
         }
 
         vector<PlaylistResponseDTO> playlists_dto;
@@ -132,7 +132,7 @@ namespace  music_share {
         optional<Playlist> playlist = m_playlist_rep.Find(playlist_id);
 
         if (!playlist) {
-            throw InvalidDataException();
+            return {};
         }
 
         return playlist->GetSongIds();

--- a/lib/mus-internal/mus-usecase/src/playlist_use_case.cc
+++ b/lib/mus-internal/mus-usecase/src/playlist_use_case.cc
@@ -90,7 +90,7 @@ namespace  music_share {
         m_playlist_rep.Update(*playlist);
     }
 
-    vector<PlaylistResponseDTO> PlaylistUseCase::GetByUserId(uint32_t user_id) {
+    vector<PlaylistResponseDTO> PlaylistUseCase::GetByUserId(uint32_t user_id) const {
         vector<Playlist> playlists = m_playlist_rep.FindByUserId(user_id);
 
         if (playlists.empty()) {
@@ -112,7 +112,7 @@ namespace  music_share {
         return playlists_dto;
     }
 
-    PlaylistResponseDTO PlaylistUseCase::GetById(uint32_t id) {
+    PlaylistResponseDTO PlaylistUseCase::GetById(uint32_t id) const {
         optional<Playlist> playlist = m_playlist_rep.Find(id);
 
         if (!playlist) {
@@ -128,7 +128,7 @@ namespace  music_share {
                                    playlist->GetTitle());
     }
 
-    vector<uint32_t> PlaylistUseCase::GetSongs(uint32_t playlist_id) {
+    vector<uint32_t> PlaylistUseCase::GetSongs(uint32_t playlist_id) const {
         optional<Playlist> playlist = m_playlist_rep.Find(playlist_id);
 
         if (!playlist) {

--- a/lib/mus-internal/mus-usecase/src/song_use_case.cc
+++ b/lib/mus-internal/mus-usecase/src/song_use_case.cc
@@ -26,7 +26,7 @@ namespace music_share {
         return *this;
     }
 
-    SongResponseDTO SongUseCase::GetById(uint32_t id) {
+    SongResponseDTO SongUseCase::GetById(uint32_t id) const {
         optional<Song> song = m_song_rep.Find(id);
 
         if (!song) {
@@ -42,7 +42,7 @@ namespace music_share {
                                song->GetUrl());
     }
 
-    vector<SongResponseDTO> SongUseCase::GetByTitle(const string& title) {
+    vector<SongResponseDTO> SongUseCase::GetByTitle(const string& title) const {
         vector<Song> songs = m_song_rep.FindByTitle(title);
 
         if (songs.empty()) {
@@ -64,7 +64,7 @@ namespace music_share {
         return songs_dto;
     }
 
-    vector<SongResponseDTO> SongUseCase::GetByArtist(const string& artist) {
+    vector<SongResponseDTO> SongUseCase::GetByArtist(const string& artist) const {
         vector<Song> songs = m_song_rep.FindByArtist(artist);
 
         if (songs.empty()) {

--- a/lib/mus-internal/mus-usecase/src/song_use_case.cc
+++ b/lib/mus-internal/mus-usecase/src/song_use_case.cc
@@ -42,8 +42,8 @@ namespace music_share {
                                song->GetUrl());
     }
 
-    vector<SongResponseDTO> SongUseCase::GetByArtistAndTitle(const optional<string>& artist,
-                                                            const optional<string>& title) const {
+    vector<SongResponseDTO> SongUseCase::GetByArtistAndTitle(const optional<string> artist,
+                                                            const optional<string> title) const {
         vector<Song> songs;
 
         if (!title && !artist) {

--- a/lib/mus-internal/mus-usecase/src/user_use_case.cc
+++ b/lib/mus-internal/mus-usecase/src/user_use_case.cc
@@ -83,7 +83,7 @@ namespace music_share {
                                user->GetNickname());
     }
 
-    vector<UserResponseDTO> UserUseCase::GetByNicknames(const vector<string>& nicknames) const {
+    vector<UserResponseDTO> UserUseCase::GetByNicknames(const vector<string> nicknames) const {
         vector<User> users;
 
         if (nicknames.empty()) {

--- a/lib/mus-internal/mus-usecase/src/user_use_case.cc
+++ b/lib/mus-internal/mus-usecase/src/user_use_case.cc
@@ -68,7 +68,7 @@ namespace music_share {
                                user_dto.nickname);
     }
 
-    UserResponseDTO UserUseCase::GetByUsername(const string& username) {
+    UserResponseDTO UserUseCase::GetByUsername(const string& username) const {
         optional<User> user = m_user_rep.FindByUsername(username);
 
         if (!user) {
@@ -83,7 +83,7 @@ namespace music_share {
                                user->GetNickname());
     }
 
-    vector<UserResponseDTO> UserUseCase::GetByNicknames(const vector<string>& nicknames) {
+    vector<UserResponseDTO> UserUseCase::GetByNicknames(const vector<string>& nicknames) const {
         vector<User> users;
         users.reserve(nicknames.size());
 
@@ -112,7 +112,7 @@ namespace music_share {
          return users_dto;
     }
 
-    UserResponseDTO UserUseCase::GetById(uint32_t id) {
+    UserResponseDTO UserUseCase::GetById(uint32_t id) const {
         optional<User> user = m_user_rep.Find(id);
 
         if (!user) {

--- a/lib/mus-internal/mus-usecase/src/user_use_case.cc
+++ b/lib/mus-internal/mus-usecase/src/user_use_case.cc
@@ -28,13 +28,13 @@ namespace music_share {
     }
 
     uint32_t UserUseCase::Create(const UserRequestDTO& user_dto) {
-        optional<User> user_valid = m_user_rep.FindByUsername(user_dto.username);
-        if (user_valid) {
+        optional<User> user_exist = m_user_rep.FindByUsername(user_dto.username);
+        if (user_exist) {
             throw ExistException();
         }
 
-        user_valid = m_user_rep.FindByEmail(user_dto.email);
-        if (user_valid) {
+        user_exist = m_user_rep.FindByEmail(user_dto.email);
+        if (user_exist) {
             throw ExistException();
         }
 

--- a/lib/mus-internal/mus-usecase/src/user_use_case.cc
+++ b/lib/mus-internal/mus-usecase/src/user_use_case.cc
@@ -38,18 +38,18 @@ namespace music_share {
             throw ExistException();
         }
 
-        auto user = make_unique<User>(user_dto.username,
-                                                    user_dto.email,
-                                                    user_dto.password,
-                                                    user_dto.nickname,
-                                                    User::AccessLevel::Authorized);
+        User user(user_dto.username,
+                  user_dto.email,
+                  user_dto.password,
+                  user_dto.nickname,
+                  User::AccessLevel::Authorized);
 
-        m_user_rep.Insert(*user);
+        m_user_rep.Insert(user);
 
-        if (!user->GetId()) {
+        if (!user.GetId()) {
             throw CreateException();
         }
-        return *user->GetId();
+        return *user.GetId();
     }
 
     UserResponseDTO UserUseCase::Update(uint32_t user_id,
@@ -88,15 +88,15 @@ namespace music_share {
         users.reserve(nicknames.size());
 
         for (const string& nickname : nicknames) {
-            vector<User> result_search = m_user_rep.FindByNickname(nickname);
+            vector<User> found_users = m_user_rep.FindByNickname(nickname);
             users.insert(users.end(),
-                         result_search.begin(),
-                         result_search.end());
+                         found_users.begin(),
+                         found_users.end());
         }
 
-         if (users.empty()) {
-             throw InvalidDataException();
-         }
+        if (users.empty()) {
+            return {};
+        }
 
          vector<UserResponseDTO> users_dto;
          users_dto.reserve(users.size());

--- a/lib/mus-internal/mus-usecase/src/user_use_case.cc
+++ b/lib/mus-internal/mus-usecase/src/user_use_case.cc
@@ -85,13 +85,17 @@ namespace music_share {
 
     vector<UserResponseDTO> UserUseCase::GetByNicknames(const vector<string>& nicknames) const {
         vector<User> users;
-        users.reserve(nicknames.size());
 
-        for (const string& nickname : nicknames) {
-            vector<User> found_users = m_user_rep.FindByNickname(nickname);
-            users.insert(users.end(),
-                         found_users.begin(),
-                         found_users.end());
+        if (nicknames.empty()) {
+            users = m_user_rep.FetchAll();
+        } else {
+            users.reserve(nicknames.size());
+            for (const string& nickname : nicknames) {
+                vector<User> found_users = m_user_rep.FindByNickname(nickname);
+                users.insert(users.end(),
+                             found_users.begin(),
+                             found_users.end());
+            }
         }
 
         if (users.empty()) {

--- a/lib/mus-internal/mus-usecase/src/user_use_case.cc
+++ b/lib/mus-internal/mus-usecase/src/user_use_case.cc
@@ -38,10 +38,10 @@ namespace music_share {
             throw ExistException();
         }
 
-        auto user = make_unique<User>(user_dto.nickname,
+        auto user = make_unique<User>(user_dto.username,
                                                     user_dto.email,
-                                                    user_dto.username,
                                                     user_dto.password,
+                                                    user_dto.nickname,
                                                     User::AccessLevel::Authorized);
 
         m_user_rep.Insert(*user);


### PR DESCRIPTION
1. Сделан корректным порядок передачи параметров в конструктор User в методе Create юзкейса для юзера.
2. Методы, которые возвращают вектор, возвращают его теперь пустым, а не кидают исключения, если данные не нашлись.
3. Метод GetByNicknames юзкейса для юзера возвращает всех юзеров, если входной запрос пустой.
4. В SonguseCase методы объединены GetByArtist и GetByTitle в метод GetByArtistAndTitle, который возвращает все песни, если запрос пустой.
5. В MessageRequestDTO и MessageResponseDTO добавлено поле playlist_id.
6. В ChatMessageUseCase добавлен метод GetByUserId, возвращающий сообщения с определенного момента времени. 